### PR TITLE
switch to goreleaser and github actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,23 +49,6 @@ jobs:
           paths:
             - bin/*
 
-  publish:
-    executor: node
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Install tools
-          command: |
-            sudo npm install -g changelog-parser
-            curl -sLO https://github.com/github/hub/releases/download/v2.14.2/hub-linux-amd64-2.14.2.tgz
-            tar -xvf hub-linux-amd64-2.14.2.tgz
-            sudo mv hub-linux-amd64-2.14.2/bin/hub /usr/local/bin/
-      - run:
-          name: publish
-          command: ./scripts/publish-release.sh $CIRCLE_TAG
-
 workflows:
   version: 2
   test:
@@ -78,16 +61,6 @@ workflows:
       - build:
           requires:
             - go-test
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only:
-                - /^v[0-9]\d*\.[0-9]\d*\.[0-9]\d*$/
-                - /^v[0-9]\d*\.[0-9]\d*\.[0-9]\d*-rc[0-9]\d*$/
-      - publish:
-          requires:
-            - build
           filters:
             branches:
               ignore: /.*/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'v[0].[0-9]+.[0-9]+'
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Unshallow
+        run: git fetch --prune --unshallow
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+      -
+        name: Import GPG key
+        id: import_gpg
+        # TODO: find alternative that is just simple gpg commands
+        # see https://github.com/hashicorp/terraform-provider-scaffolding/issues/22
+        uses: paultyng/ghaction-import-gpg@v2.1.0
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          # GitHub sets this automatically
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,45 @@
+before:
+  hooks:
+    - go mod tidy
+builds:
+- env:
+    - CGO_ENABLED=0
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  flags:
+    - -trimpath
+  ldflags:
+    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+  goos:
+    - freebsd
+    - windows
+    - linux
+    - darwin
+  goarch:
+    - amd64
+    - '386'
+    - arm
+    - arm64
+  ignore:
+    - goos: darwin
+      goarch: '386'
+  binary: '{{ .ProjectName }}_v{{ .Version }}'
+archives:
+- format: zip
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+signs:
+  - artifacts: checksum
+    args:
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+release:
+  # draft: true
+changelog:
+  skip: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ For each changelong entry sections are:
 
 ## [Unreleased]
 
+## [v0.0.2] - 2021/03/10
+
+Switch to github actions and goreleaser to be able to push to terrafrom registry
+
 ## [0.0.1] - 2020/09/16
 
 First stable version of terraform-ethereum-provider


### PR DESCRIPTION
In order to publish to terrafrom registry we need to switch to terrafrom registry and github actions ( it is the recommended way ). 

Also I've create a GPG key for adhara-tech, because the releases needs to be signed. The gpg key and it's passphrase are in keybase in a gpg folder.  